### PR TITLE
Role arn to assume from profile file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install aws-mfa-tool
 ## Usage
 
 ```
-> aws-mfa --profile example_profile --mfa-serial <mfa_serial>
+> aws-mfa create --profile example_profile --mfa-serial <mfa_serial>
 ```
 
 This will prompt your for your MFA token. On successful entry, it will print and save the temporary credentials to you `~/.aws/credentials` file. The saved profile name is _< profile_name > by default, so `_example_profile` in this example.

--- a/aws_mfa_tool/cli.py
+++ b/aws_mfa_tool/cli.py
@@ -35,8 +35,13 @@ def cli():
     '-o', '--save-output-profile',
     help='Shared credentials profile name to be written / overwritten')
 @click.option(
-    '-s', '--skip-save', is_flag=True,
+    '-s', '--skip-save',
+    is_flag=True,
     help='Skip save to shared credentials')
+@click.option(
+    '-j', '--display-json',
+    is_flag=True,
+    help='Display JSON response from the AWS API')
 def create(
     region,
     profile,
@@ -44,7 +49,8 @@ def create(
     duration,
     token_code,
     skip_save,
-    save_output_profile
+    save_output_profile,
+    display_json
 ):
     session = boto3.Session(
         profile_name=profile,
@@ -80,7 +86,8 @@ def create(
             'aws_session_token': aws_session_token,
         })
 
-    print response
+    if display_json is not False:
+        print response
 
 
 @cli.command(
@@ -118,6 +125,10 @@ def create(
     '-s', '--skip-save',
     is_flag=True,
     help='Skip save to shared credentials')
+@click.option(
+    '-j', '--display-json',
+    is_flag=True,
+    help='Display JSON response from the AWS API')
 def create(
     region,
     profile,
@@ -127,7 +138,8 @@ def create(
     duration,
     token_code,
     skip_save,
-    save_output_profile
+    save_output_profile,
+    display_json
 ):
     session = boto3.Session(
         profile_name=profile,
@@ -170,7 +182,8 @@ def create(
             'aws_session_token': aws_session_token,
         })
 
-    print response
+    if display_json is not False:
+        print response
 
 
 def write_profile(profile, values):


### PR DESCRIPTION
Adds CLI option -f / --from-profile to the assume-role command. This allows you to select the role by entering the rememberable profile name instead of the corresponding Role ARN.